### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM fishtownanalytics/dbt:0.21.1
+FROM fishtownanalytics/dbt:1.0.0
 WORKDIR /support
 RUN mkdir /root/.dbt
 COPY profiles.yml /root/.dbt


### PR DESCRIPTION
To use the new docker container, remove the old docker image
```
user@ubuntu:~/harmony_dbt$ sudo docker image ls
REPOSITORY              TAG         IMAGE ID       CREATED          SIZE
harmony_dbt_dbt_console   latest      7e73e808e25c   2 weeks ago     751MB
harmony_dbt_dbt_docs      latest      7e73e808e25c   2 weeks ago     751MB
fishtownanalytics/dbt   0.21.1      a7f3d74c55d3   5 weeks ago      751MB
hello-world             latest      feb5d9fea6a5   3 months ago     13.3kB
```
1. `sudo docker image rm a7f3d74c55d3`
2. `sudo docker image rm 7e73e808e25c --force`
3. `sudo make`

You should be on the latest container now.
