### PR TITLE
Transfers table

### DIFF
--- a/models/core/transfers.sql
+++ b/models/core/transfers.sql
@@ -1,16 +1,14 @@
 {{ 
     config(
         materialized='incremental', 
-        unique_key= "CONCAT_WS('-', 'log_id', 'block_id', 'tx_hash', coalesce('from_address',''), coalesce('to_address',''), coalesce('contract_address',''), coalesce('raw_amount',-1))",
+        unique_key= 'log_id',
         incremental_strategy = 'delete+insert',
         tags=['core'],
         cluster_by = ['block_timestamp']
     ) 
 }}
 
-with 
-
-logs as (
+with logs as (
 
   select 
 
@@ -42,7 +40,7 @@ transfers as (
 
   from logs
   where event_name::string = 'Transfer'
-  and event_inputs:value is not null
+  and raw_amount is not null
 
 ) 
 

--- a/models/core/transfers.sql
+++ b/models/core/transfers.sql
@@ -22,7 +22,7 @@ transfers as (
     block_id,
     tx_hash,
     block_timestamp,
-    evm_contract_address as contract_address,
+    evm_contract_address::string as contract_address,
     event_inputs:from::string as from_address,
     event_inputs:to::string as to_address,
     event_inputs:value::float as raw_amount

--- a/models/core/transfers.sql
+++ b/models/core/transfers.sql
@@ -12,7 +12,7 @@ with logs as (
     q.block_timestamp, 
     q.tx_hash,
     q.evm_contract_address, 
-    q.eventName, 
+    q.event_name, 
     q.event_inputs
   from 
     {{ ref('logs') }} q
@@ -29,7 +29,7 @@ transfers as (
   from 
     logs
   where 
-    eventName::string = 'Transfer'
+    event_name::string = 'Transfer'
   and 
     event_inputs:value is not null
 ) 

--- a/models/core/transfers.sql
+++ b/models/core/transfers.sql
@@ -39,7 +39,7 @@ transfers as (
     event_inputs:value::float as raw_amount
 
   from logs
-  where event_name::string = 'Transfer'
+  where event_name = 'Transfer'
   and raw_amount is not null
 
 ) 

--- a/models/core/transfers.sql
+++ b/models/core/transfers.sql
@@ -1,0 +1,40 @@
+{{ config(
+  materialized='incremental', 
+  unique_key= "CONCAT_WS('-', 'block_id', 'tx_hash', coalesce('from_address',''), coalesce('to_address',''), coalesce('contract_address',''), coalesce('raw_amount',-1))",
+  incremental_strategy = 'delete+insert',
+  cluster_by = ['block_timestamp'],
+  tags=['core']
+) }}
+
+with logs as (
+  select 
+    q.block_id, 
+    q.block_timestamp, 
+    q.tx_hash,
+    q.evm_contract_address, 
+    q.eventName, 
+    q.event_inputs
+  from 
+    {{ ref('logs') }} q
+),
+transfers as (
+  select
+    block_id,
+    tx_hash,
+    block_timestamp,
+    evm_contract_address as contract_address,
+    event_inputs:from::string as from_address,
+    event_inputs:to::string as to_address,
+    event_inputs:value::float as raw_amount
+  from 
+    logs
+  where 
+    eventName::string = 'Transfer'
+  and 
+    event_inputs:value is not null
+) 
+select 
+  *
+from 
+  transfers
+

--- a/models/core/transfers.sql
+++ b/models/core/transfers.sql
@@ -1,24 +1,37 @@
-{{ config(
-  materialized='incremental', 
-  unique_key= "CONCAT_WS('-', 'block_id', 'tx_hash', coalesce('from_address',''), coalesce('to_address',''), coalesce('contract_address',''), coalesce('raw_amount',-1))",
-  incremental_strategy = 'delete+insert',
-  cluster_by = ['block_timestamp'],
-  tags=['core']
-) }}
+{{ 
+    config(
+        materialized='incremental', 
+        unique_key= "CONCAT_WS('-', 'log_id', 'block_id', 'tx_hash', coalesce('from_address',''), coalesce('to_address',''), coalesce('contract_address',''), coalesce('raw_amount',-1))",
+        incremental_strategy = 'delete+insert',
+        tags=['core'],
+        cluster_by = ['block_timestamp']
+    ) 
+}}
 
-with logs as (
+with 
+
+logs as (
+
   select 
-    q.block_id, 
-    q.block_timestamp, 
-    q.tx_hash,
-    q.evm_contract_address, 
-    q.event_name, 
-    q.event_inputs
-  from 
-    {{ ref('logs') }} q
+
+    log_id,
+    block_id, 
+    block_timestamp, 
+    tx_hash,
+    evm_contract_address, 
+    event_name, 
+    event_inputs
+
+  from {{ ref('logs') }}
+  where {{ incremental_load_filter("block_timestamp") }}
+
 ),
+
 transfers as (
+
   select
+
+    log_id,
     block_id,
     tx_hash,
     block_timestamp,
@@ -26,15 +39,11 @@ transfers as (
     event_inputs:from::string as from_address,
     event_inputs:to::string as to_address,
     event_inputs:value::float as raw_amount
-  from 
-    logs
-  where 
-    event_name::string = 'Transfer'
-  and 
-    event_inputs:value is not null
-) 
-select 
-  *
-from 
-  transfers
 
+  from logs
+  where event_name::string = 'Transfer'
+  and event_inputs:value is not null
+
+) 
+
+select * from transfers

--- a/models/core/transfers.yml
+++ b/models/core/transfers.yml
@@ -3,34 +3,46 @@ version: 2
 
 models:
   - name: transfers
-    description: "Harmony transfer events"
+    description: "Harmony transfer events."
+
     columns:
+      - name: log_id
+        description: Log identifier composed of tx_hash-event_index.
+        tests:
+          - unique
+          - not_null
+
       - name: block_id
-        description: The block ID
+        description: The block ID.
         tests:
           - not_null
+
       - name: tx_hash
-        description: The transaction hash
+        description: The transaction hash.
         tests:
         - not_null
+
       - name: block_timestamp
-        description: The time the block was minted
+        description: The time the block was minted.
         tests:
           - not_null
-      - name: chain_id
+
       - name: contract_address
-        description: The address of the transferred token
+        description: The address of the transferred token.
         tests:
           - not_null
+
       - name: from_address
-        description: The address sent the token
+        description: The address sent the token.
         tests:
           - not_null
+
       - name: to_address
-        description: The address received the token
+        description: The address received the token.
         tests:
           - not_null
+          
       - name: raw_amount
-        description: The token's raw amount
+        description: The token's raw amount.
         tests:
           - not_null

--- a/models/core/transfers.yml
+++ b/models/core/transfers.yml
@@ -1,0 +1,36 @@
+
+version: 2
+
+models:
+  - name: transfers
+    description: "Harmony transfer events"
+    columns:
+      - name: block_id
+        description: The block ID
+        tests:
+          - not_null
+      - name: tx_hash
+        description: The transaction hash
+        tests:
+        - not_null
+      - name: block_timestamp
+        description: The time the block was minted
+        tests:
+          - not_null
+      - name: chain_id
+      - name: contract_address
+        description: The address of the transferred token
+        tests:
+          - not_null
+      - name: from_address
+        description: The address sent the token
+        tests:
+          - not_null
+      - name: to_address
+        description: The address received the token
+        tests:
+          - not_null
+      - name: raw_amount
+        description: The token's raw amount
+        tests:
+          - not_null


### PR DESCRIPTION
dbt run --select harmony.core.transfers
Running with dbt=0.21.1
Found 6 models, 58 tests, 0 snapshots, 0 analyses, 175 macros, 0 operations, 0 seed files, 2 sources, 0 exposures

18:45:32 | Concurrency: 4 threads (target='dev')
18:45:32 |
18:45:32 | 1 of 1 START incremental model DEV.transfers......................... [RUN]
18:46:17 | 1 of 1 OK created incremental model DEV.transfers.................... [SUCCESS 1 in 45.05s]
18:46:17 |
18:46:17 | Finished running 1 incremental model in 50.75s.

Completed successfully

Done. PASS=1 WARN=0 ERROR=0 SKIP=0 TOTAL=1

The table is available at harmony.dev.transfers

