### PR TITLE
Add `btc_bridge`

### DIFF
--- a/models/core/btc_bridge.sql
+++ b/models/core/btc_bridge.sql
@@ -1,0 +1,43 @@
+{{ 
+    config(
+        materialized='incremental', 
+        unique_key= 'log_id',
+        incremental_strategy = 'delete+insert',
+        tags=['core'],
+        cluster_by = ['block_timestamp']
+    ) 
+}}
+-- Collateral is required to launch a vault
+with vaults as (
+
+select 
+  distinct event_inputs:_to::string as vault_address
+from {{ ref('logs') }}
+where 
+  evm_contract_address = '0xdc54046c0451f9269fee1840aec808d36015697d' -- HMY_ONE_BTC_CONTRACT
+  and event_name = 'IssueTokens'
+
+)
+
+select 
+  log_id,
+  block_id,
+  tx_hash,
+  block_timestamp,
+  contract_address,
+  from_address,
+  to_address,
+  case 
+    when from_address = '0x0000000000000000000000000000000000000000' then 'issue'
+    when to_address = '0x0000000000000000000000000000000000000000' then 'redeem'
+  end as tx_type,
+  v.vault_address is not null as is_vault,
+  raw_amount
+from {{ ref('transfers') }} as t 
+left join vaults as v 
+  on t.to_address = v.vault_address
+where 
+  {{ incremental_load_filter("block_timestamp") }}
+  and contract_address = '0xdc54046c0451f9269fee1840aec808d36015697d' -- HMY_ONE_BTC_CONTRACT
+  and (from_address = '0x0000000000000000000000000000000000000000'  -- issue
+       or to_address = '0x0000000000000000000000000000000000000000') -- redeem

--- a/models/core/btc_bridge.sql
+++ b/models/core/btc_bridge.sql
@@ -32,25 +32,29 @@ transfers as (
     *
   from  {{ ref('transfers') }}
   where {{ incremental_load_filter("block_timestamp") }}
+),
+final as (
+  select 
+    t.log_id,
+    t.block_id,
+    t.tx_hash,
+    t.block_timestamp,
+    t.contract_address,
+    t.from_address,
+    t.to_address,
+    case 
+      when t.from_address = '0x0000000000000000000000000000000000000000' then 'issue'
+      when t.to_address = '0x0000000000000000000000000000000000000000' then 'redeem'
+    end as tx_type,
+    v.vault_address is not null as is_vault,
+    t.raw_amount
+  from transfers as t 
+  left join vaults as v 
+    on t.to_address = v.vault_address
+  where 
+    t.contract_address = '0xdc54046c0451f9269fee1840aec808d36015697d' -- HMY_ONE_BTC_CONTRACT
+    and (t.from_address = '0x0000000000000000000000000000000000000000'  -- issue
+        or t.to_address = '0x0000000000000000000000000000000000000000') -- redeem
 )
-select 
-  t.log_id,
-  t.block_id,
-  t.tx_hash,
-  t.block_timestamp,
-  t.contract_address,
-  t.from_address,
-  t.to_address,
-  case 
-    when t.from_address = '0x0000000000000000000000000000000000000000' then 'issue'
-    when t.to_address = '0x0000000000000000000000000000000000000000' then 'redeem'
-  end as tx_type,
-  v.vault_address is not null as is_vault,
-  t.raw_amount
-from transfers as t 
-left join vaults as v 
-  on t.to_address = v.vault_address
-where 
-  t.contract_address = '0xdc54046c0451f9269fee1840aec808d36015697d' -- HMY_ONE_BTC_CONTRACT
-  and (t.from_address = '0x0000000000000000000000000000000000000000'  -- issue
-       or t.to_address = '0x0000000000000000000000000000000000000000') -- redeem
+
+select * from final

--- a/models/core/btc_bridge.sql
+++ b/models/core/btc_bridge.sql
@@ -8,36 +8,49 @@
     ) 
 }}
 -- Collateral is required to launch a vault
-with vaults as (
+with logs as (
 
   select 
-    distinct event_inputs:_to::string as vault_address
+    *
   from {{ ref('logs') }}
+  where {{ incremental_load_filter("block_timestamp") }}
+
+),
+vaults as (
+
+  select 
+    distinct 
+      event_inputs:_to::string as vault_address
+  from logs
   where 
     evm_contract_address = '0xdc54046c0451f9269fee1840aec808d36015697d' -- HMY_ONE_BTC_CONTRACT
     and event_name = 'IssueTokens'
 
+),
+transfers as (
+  select 
+    *
+  from  {{ ref('transfers') }}
+  where {{ incremental_load_filter("block_timestamp") }}
 )
-
 select 
-  log_id,
-  block_id,
-  tx_hash,
-  block_timestamp,
-  contract_address,
-  from_address,
-  to_address,
+  t.log_id,
+  t.block_id,
+  t.tx_hash,
+  t.block_timestamp,
+  t.contract_address,
+  t.from_address,
+  t.to_address,
   case 
-    when from_address = '0x0000000000000000000000000000000000000000' then 'issue'
-    when to_address = '0x0000000000000000000000000000000000000000' then 'redeem'
+    when t.from_address = '0x0000000000000000000000000000000000000000' then 'issue'
+    when t.to_address = '0x0000000000000000000000000000000000000000' then 'redeem'
   end as tx_type,
   v.vault_address is not null as is_vault,
-  raw_amount
-from {{ ref('transfers') }} as t 
+  t.raw_amount
+from transfers as t 
 left join vaults as v 
   on t.to_address = v.vault_address
 where 
-  {{ incremental_load_filter("block_timestamp") }}
-  and contract_address = '0xdc54046c0451f9269fee1840aec808d36015697d' -- HMY_ONE_BTC_CONTRACT
-  and (from_address = '0x0000000000000000000000000000000000000000'  -- issue
-       or to_address = '0x0000000000000000000000000000000000000000') -- redeem
+  t.contract_address = '0xdc54046c0451f9269fee1840aec808d36015697d' -- HMY_ONE_BTC_CONTRACT
+  and (t.from_address = '0x0000000000000000000000000000000000000000'  -- issue
+       or t.to_address = '0x0000000000000000000000000000000000000000') -- redeem

--- a/models/core/btc_bridge.sql
+++ b/models/core/btc_bridge.sql
@@ -10,12 +10,12 @@
 -- Collateral is required to launch a vault
 with vaults as (
 
-select 
-  distinct event_inputs:_to::string as vault_address
-from {{ ref('logs') }}
-where 
-  evm_contract_address = '0xdc54046c0451f9269fee1840aec808d36015697d' -- HMY_ONE_BTC_CONTRACT
-  and event_name = 'IssueTokens'
+  select 
+    distinct event_inputs:_to::string as vault_address
+  from {{ ref('logs') }}
+  where 
+    evm_contract_address = '0xdc54046c0451f9269fee1840aec808d36015697d' -- HMY_ONE_BTC_CONTRACT
+    and event_name = 'IssueTokens'
 
 )
 

--- a/models/core/btc_bridge.yml
+++ b/models/core/btc_bridge.yml
@@ -1,0 +1,89 @@
+version: 2
+
+models:
+  - name: btc_bridge
+    description: |- 
+      "This table records BTC bridging activites to and out of Harmony."
+
+      ### Example Queries
+      ```sql
+      -- To find out how much BTC bridged to Harmony in the last 7 days
+      select
+        sum(raw_amount)/1e8 as btc_amount
+      from harmony.prod.btc_bridge
+      where 
+        block_timestamp > current_timestamp() - interval '7 days'
+        and tx_type = 'issue'
+      ```
+
+      ```sql
+      -- To find out TVL of BTC on Harmony
+      select 
+        sum(raw_amount)/1e8 as tvl
+      from (
+          select
+            date_trunc('day', block_timestamp) as day,
+            tx_type,
+            case 
+              when tx_type = 'redeem' then -1 * sum(raw_amount) 
+              else sum(raw_amount) end as raw_amount
+          from harmony.dev.btc_bridge
+          group by 1, 2
+      ) as x 
+      ```
+
+    columns:
+      - name: log_id
+        description: Log identifier composed of tx_hash-event_index.
+        tests:
+          - unique
+          - not_null
+
+      - name: block_id
+        description: The block ID.
+        tests:
+          - not_null
+
+      - name: tx_hash
+        description: The transaction hash.
+        tests:
+          - not_null
+
+      - name: block_timestamp
+        description: The time the block was minted.
+        tests:
+          - not_null
+
+      - name: contract_address
+        description: The address of the transferred token.
+        tests:
+          - not_null
+
+      - name: from_address
+        description: The address sent the token.
+        tests:
+          - not_null
+
+      - name: to_address
+        description: The address received the token.
+        tests:
+          - not_null
+
+      - name: tx_type
+        description: The type of transaction, including `issue` or `redeem`.
+        tests:
+          - not_null
+          - accepted_values:
+              values: ["issue", "redeem"]
+              quote: true
+              severity: warn
+
+      - name: is_vault
+        description: Whether the `to_address` that 1BTC token is issued to is a vault. This only applies to `issue` transaction type.
+        tests:
+          - not_null
+
+      - name: raw_amount
+        description: The 1BTC token's raw amount.
+        tests:
+          - not_null


### PR DESCRIPTION
### Description
Adding transfers related to BTC bridging to Harmony.
close #54 

Would like to know thoughts on:
- If we need the `is_vault` label or we can just ignore them and combine everything together

### Test
```
dbt run -s core.btc_bridge --full-refresh
Running with dbt=0.21.1
Found 21 models, 139 tests, 0 snapshots, 0 analyses, 177 macros, 0 operations, 3 seed files, 2 sources, 0 exposures

12:56:40 | Concurrency: 4 threads (target='dev')
12:56:40 | 
12:56:40 | 1 of 1 START incremental model DEV.btc_bridge........................ [RUN]
12:56:50 | 1 of 1 OK created incremental model DEV.btc_bridge................... [SUCCESS 1 in 9.92s]
12:56:50 | 
12:56:50 | Finished running 1 incremental model in 18.17s.

Completed successfully

Done. PASS=1 WARN=0 ERROR=0 SKIP=0 TOTAL=1
```

<img width="1386" alt="image" src="https://user-images.githubusercontent.com/30974572/155139120-be9928a4-5a29-4c69-9892-4ad92e64dccf.png">
