### PR TITLE
Add validators table

### DIFF
--- a/macros/incremental_utils.sql
+++ b/macros/incremental_utils.sql
@@ -7,6 +7,15 @@
     {% endif %}
 {%- endmacro %}
 
+{% macro incremental_load_filter_2(time_col_other, time_col_this) -%}
+    -- dbt makes it easy to query your target table by using the "{{ this }}" variable.
+    {% if is_incremental() %}
+      {{ time_col_other }} > (select max({{ time_col_this }}) from {{ this }})
+    {%- else -%}
+      true
+    {% endif %}
+{%- endmacro %}
+
 {% macro incremental_last_x_days(time_col, time_in_days) -%}
     {% if is_incremental() %}
         {{ time_col }} >= current_date() - interval '{{ time_in_days }} day'

--- a/models/core/validators.sql
+++ b/models/core/validators.sql
@@ -1,7 +1,7 @@
 {{
 	config(
 		materialized='incremental',
-		unique_key='log_id',
+		unique_key='u_key',
 		tags=['core'],
 		cluster_by=['day_date']
 	)
@@ -81,7 +81,7 @@ validators as (
 
 final as (
 	select
-		concat_ws('-', to_char(day_date, '%Y%m%d'), validator_address) as log_id,
+		concat_ws('-', to_char(day_date, '%Y%m%d'), validator_address) as u_key,
 		*
 	from validators
 )

--- a/models/core/validators.sql
+++ b/models/core/validators.sql
@@ -1,22 +1,23 @@
 {{
-	config(
-		materialized='incremental',
-		unique_key='u_key',
-		tags=['core'],
-		cluster_by=['day_date']
-	)
+    config(
+        materialized='incremental',
+        unique_key='u_key',
+        tags=['core'],
+        cluster_by=['day_date']
+    )
 }}
 
 with delegators_incremental as (
-	select
-	    *
-	from {{ ref('stg_delegators') }}
-	where {{ incremental_load_filter('ingest_timestamp') }}
+    select
+        *
+    from {{ ref('stg_delegators') }}
+    where {{ incremental_load_filter_2('ingest_timestamp', 'day_date') }}
+    
 ),
 
 latest_day_timestamps as (
     select
-	day_date,
+        day_date,
         validator_address,
         max(ingest_timestamp) as ingest_timestamp
     from delegators_incremental
@@ -29,8 +30,8 @@ latest_day_flat_delegations as (
         ingest_timestamp,
         validator_address
     from delegators_incremental
-	natural join latest_day_timestamps
-	inner join lateral flatten(input => delegations)
+    natural join latest_day_timestamps
+    inner join lateral flatten(input => delegations)
 ),
 
 rewards as (
@@ -48,7 +49,7 @@ undelegations as (
         validator_address,
         sum(ifnull(flat_undelegations.value:amount, 0)) as amount
     from latest_day_flat_delegations
-	inner join lateral flatten(input => value:undelegations, outer => true) flat_undelegations
+    inner join lateral flatten(input => value:undelegations, outer => true) flat_undelegations
     group by 1, 2
 ),
 
@@ -58,33 +59,34 @@ totals as (
         rewards.validator_address as validator_address,
         rewards.amount as total_one_rewarded,
         undelegations.amount as total_one_undelegated
-    from rewards join undelegations
-    on rewards.ingest_timestamp = undelegations.ingest_timestamp
-    and rewards.validator_address = undelegations.validator_address
+    from rewards
+    join undelegations
+        on rewards.ingest_timestamp = undelegations.ingest_timestamp
+        and rewards.validator_address = undelegations.validator_address
 ),
 
 validators as (
-	select
-		day_date,
-		delegators_incremental.validator_address as validator_address,
-		js_onetohex(delegators_incremental.validator_address) as validator_hex_address,
-		validator_identity,
-		active_status,
-		booted_status,
-		total_delegation as total_one_delegated,
-		ifnull(total_one_rewarded, 0) as total_one_rewarded,
-		ifnull(total_one_undelegated, 0) as total_one_undelegated
-	from delegators_incremental
-	join totals 
-	on delegators_incremental.ingest_timestamp = totals.ingest_timestamp
-	and delegators_incremental.validator_address = totals.validator_address
+    select
+        day_date,
+        delegators_incremental.validator_address as validator_address,
+        js_onetohex(delegators_incremental.validator_address) as validator_hex_address,
+        validator_identity,
+        active_status,
+        booted_status,
+        total_delegation as total_one_delegated,
+        ifnull(total_one_rewarded, 0) as total_one_rewarded,
+        ifnull(total_one_undelegated, 0) as total_one_undelegated
+    from delegators_incremental
+    join totals 
+        on delegators_incremental.ingest_timestamp = totals.ingest_timestamp
+        and delegators_incremental.validator_address = totals.validator_address
 ),
 
 final as (
-	select
-		concat_ws('-', to_char(day_date, '%Y%m%d'), validator_address) as u_key,
-		*
-	from validators
+    select
+        concat_ws('-', to_char(day_date, '%Y%m%d'), validator_address) as u_key,
+        *
+    from validators
 )
 
 select * from final

--- a/models/core/validators.sql
+++ b/models/core/validators.sql
@@ -16,10 +16,11 @@ with delegators_incremental as (
 
 latest_day_timestamps as (
     select
-        max(ingest_timestamp) as ingest_timestamp,
-        validator_address
+	day_date,
+        validator_address,
+        max(ingest_timestamp) as ingest_timestamp
     from delegators_incremental
-    group by day_date, validator_address
+    group by 1, 2
 ),
 
 latest_day_flat_delegations as (
@@ -38,7 +39,7 @@ rewards as (
         validator_address,
         sum(value:reward) as amount
     from latest_day_flat_delegations
-    group by ingest_timestamp, validator_address
+    group by 1, 2
 ),
 
 undelegations as (
@@ -48,7 +49,7 @@ undelegations as (
         sum(ifnull(flat_undelegations.value:amount, 0)) as amount
     from latest_day_flat_delegations
 	inner join lateral flatten(input => value:undelegations, outer => true) flat_undelegations
-    group by ingest_timestamp, validator_address
+    group by 1, 2
 ),
 
 totals as (

--- a/models/core/validators.sql
+++ b/models/core/validators.sql
@@ -9,7 +9,7 @@
 
 with delegators_incremental as (
 	select *
-	from {{ ref('stg_delegators') }}
+	from harmony.dev.stg_delegators
 	where {{ incremental_load_filter('ingest_timestamp') }}
 ),
 

--- a/models/core/validators.sql
+++ b/models/core/validators.sql
@@ -57,7 +57,9 @@ totals as (
         validator_address,
         rewards.amount as total_one_rewarded,
         undelegations.amount as total_one_undelegated
-    from rewards join undelegations using (ingest_timestamp, validator_address)
+    from rewards join undelegations
+    on rewards.ingest_timestamp = undelegations.ingest_timestamp
+    and rewards.validator_address = undelegations.validator_address
 ),
 
 validators as (
@@ -72,7 +74,9 @@ validators as (
 		ifnull(total_one_rewarded, 0) as total_one_rewarded,
 		ifnull(total_one_undelegated, 0) as total_one_undelegated
 	from delegators_incremental
-	join totals using (ingest_timestamp, validator_address)
+	join totals 
+	on delegators_incremental.ingest_timestamp = totals.ingest_timestamp
+	and delegators_incremental.validator_address = totals.validator_address
 ),
 
 final as (

--- a/models/core/validators.sql
+++ b/models/core/validators.sql
@@ -8,7 +8,8 @@
 }}
 
 with delegators_incremental as (
-	select *
+	select
+	    *
 	from {{ ref('stg_delegators') }}
 	where {{ incremental_load_filter('ingest_timestamp') }}
 ),

--- a/models/core/validators.sql
+++ b/models/core/validators.sql
@@ -1,0 +1,79 @@
+{{
+	config(
+		materialized='incremental',
+		unique_key='log_id',
+		tags=['core'],
+		cluster_by=['day_date']
+	)
+}}
+
+with latest_day_timestamps as (
+    select
+        max(ingest_timestamp) as ingest_timestamp,
+        validator_address
+    from {{ ref('stg_delegators') }}
+    group by day_date, validator_address
+	where {{ incremental_load_filter('ingest_timestamp') }}
+),
+
+latest_day_flat_delegations as (
+    select
+        value,
+        ingest_timestamp,
+        validator_address
+    from {{ ref('stg_delegators') }}
+	natural join latest_day_timestamps
+	inner join lateral flatten(input => delegations)
+),
+
+rewards as (
+    select
+        ingest_timestamp,
+        validator_address,
+        sum(value:reward) as amount
+    from latest_day_flat_delegations
+    group by ingest_timestamp, validator_address
+),
+
+undelegations as (
+    select
+        ingest_timestamp,
+        validator_address,
+        sum(ifnull(flat_undelegations.value:amount, 0)) as amount
+    from latest_day_flat_delegations
+	inner join lateral flatten(input => value:undelegations, outer => true) flat_undelegations
+    group by ingest_timestamp, validator_address
+),
+
+totals as (
+    select
+        ingest_timestamp,
+        validator_address,
+        rewards.amount as total_one_rewarded,
+        undelegations.amount as total_one_undelegated
+    from rewards join undelegations using (ingest_timestamp, validator_address)
+),
+
+validators as (
+	select
+		day_date,
+		validator_address,
+		js_onetohex(validator_address) as validator_hex_address,
+		validator_identity,
+		active_status,
+		booted_status,
+		total_delegation as total_one_delegated,
+		ifnull(total_one_rewarded, 0) as total_one_rewarded,
+		ifnull(total_one_undelegated, 0) as total_one_undelegated
+	from dev.stg_delegators
+	join totals using (ingest_timestamp, validator_address
+),
+
+final as (
+	select
+		concat_ws('-', to_char(day_date, '%Y%m%d'), validator_address) as log_id,
+		*
+	from validators
+)
+
+select * from final

--- a/models/core/validators.sql
+++ b/models/core/validators.sql
@@ -54,8 +54,8 @@ undelegations as (
 
 totals as (
     select
-        ingest_timestamp,
-        validator_address,
+        rewards.ingest_timestamp as ingest_timestamp,
+        rewards.validator_address as validator_address,
         rewards.amount as total_one_rewarded,
         undelegations.amount as total_one_undelegated
     from rewards join undelegations
@@ -66,8 +66,8 @@ totals as (
 validators as (
 	select
 		day_date,
-		validator_address,
-		js_onetohex(validator_address) as validator_hex_address,
+		delegators_incremental.validator_address as validator_address,
+		js_onetohex(delegators_incremental.validator_address) as validator_hex_address,
 		validator_identity,
 		active_status,
 		booted_status,

--- a/models/core/validators.sql
+++ b/models/core/validators.sql
@@ -9,7 +9,7 @@
 
 with delegators_incremental as (
 	select *
-	from harmony.dev.stg_delegators
+	from {{ ref('stg_delegators') }}
 	where {{ incremental_load_filter('ingest_timestamp') }}
 ),
 

--- a/models/core/validators.yml
+++ b/models/core/validators.yml
@@ -6,8 +6,8 @@ models:
       This table records various daily statistics of Harmony validators.
 
     columns:
-      - name: log_id
-        description: The log ID composed of the date and validator address.
+      - name: u_key
+        description: The daily update key composed of the date and validator address.
         tests:
           - unique
           - not_null

--- a/models/core/validators.yml
+++ b/models/core/validators.yml
@@ -1,0 +1,59 @@
+version: 2
+
+models:
+  - name: validators
+    description: |-
+      This table records various daily statistics of Harmony validators.
+
+    columns:
+      - name: log_id
+        description: The log ID composed of the date and validator address.
+        tests:
+          - unique
+          - not_null
+
+      - name: day_date
+        description: The date of this log.
+        tests:
+          - not_null
+
+      - name: validator_address
+        description: The validator's native Harmony address.
+        tests:
+          - not_null
+
+      - name: validator_hex_address
+        description: The validator's address in hex format.
+        tests:
+          - not_null
+
+      - name: validator_identity
+        description: The validator's provided identity.
+        tests:
+          - not_null
+
+      - name: active_status
+        description: The validator's active status.
+        tests:
+          - not_null
+
+      - name: booted_status
+        description: |-
+          The reason for booting this validator off the network.
+          NULL if validator is active and not booted.
+        tests:
+
+      - name: total_one_delegated
+        description: The total amount of ONE delegated to this validator in ATTO format (a factor of 10^18).
+        tests:
+          - not_null
+
+      - name: total_one_rewarded
+        description: The total amount of ONE rewarded by this validator to delegators in ATTO format (a factor of 10^18).
+        tests:
+          - not_null
+
+      - name: total_one_undelegated
+        description: The total amount of ONE undelegated from this validator in ATTO format (a factor of 10^18).
+        tests:
+          - not_null


### PR DESCRIPTION
Following schema and discussion at https://github.com/MetricsDAO/harmony_dbt/issues/73

### Testing

```txt
root@03e8142ce188:/harmony# dbt run --select validators
Running with dbt=0.21.1
Found 35 models, 284 tests, 0 snapshots, 0 analyses, 178 macros, 0 operations, 8 seed files, 6 sources, 0 exposures

14:10:33 | Concurrency: 4 threads (target='dev')
14:10:33 |
14:10:33 | 1 of 1 START incremental model DEV.validators........................ [RUN]
14:10:53 | 1 of 1 OK created incremental model DEV.validators................... [SUCCESS 1 in 20.30s]
14:10:53 |
14:10:53 | Finished running 1 incremental model in 34.62s.

Completed successfully

Done. PASS=1 WARN=0 ERROR=0 SKIP=0 TOTAL=1
```

![image](https://user-images.githubusercontent.com/51023861/159721364-ec27a907-479e-423a-a82d-328a00c7eb7d.png)

### Future

Currently, makes direct reference to `harmony.dev.stg_delegators`. Perhaps an issue can be created to make a change when `stg_delegators` is commited to production.