### PR TITLE
Create sushiswap-lp-actions sql

### DIFF
--- a/models/core/sushiswap_lp_actions.sql
+++ b/models/core/sushiswap_lp_actions.sql
@@ -1,0 +1,127 @@
+{{
+    config(
+        materialized='incremental',
+        unique_key='log_id',
+        tags=['core', 'sushiswap_lp_actions'],
+        cluster_by=['log_id']
+        )
+}}
+
+
+with 
+
+events as (
+    select 
+        log_id,
+        block_timestamp,
+        date_trunc('day', block_timestamp) as block_date,
+        tx_hash,
+        event_index,
+        native_contract_address,
+        evm_contract_address,
+        
+        case 
+            when event_name='Mint' 
+                then 'ADD_LIQUIDITY'
+            else 'REMOVE_LIQUIDITY'
+        end as action,
+    
+        event_inputs:amount0::int as amount0_raw,
+    
+        event_inputs:amount1::int as amount1_raw
+    
+    from {{ ref('logs') }}
+    where (event_name='Mint' or 
+           event_name='Burn') 
+        and event_inputs:sender = '0x1b02da8cb0d097eb8d57a175b88c7d8b47997506'
+),
+
+txs as (
+    select
+        tx_hash,
+        from_address
+    from {{ ref('txs') }}
+),
+
+liquidity_pools as (
+    select *
+    from {{ ref('liquidity_pools') }}
+),
+
+tokenprices as (
+    select * 
+    from {{ ref('tokenprices') }}
+),
+
+tokens as (
+    select *
+    from {{ ref('tokens') }}
+),
+
+events_liquidity_pools as (
+    select 
+        events.log_id,
+        events.block_timestamp,
+        events.block_date,
+        events.tx_hash,
+        liquidity_pools.*,
+        events.action,
+        events.amount0_raw,
+        events.amount1_raw
+    from events
+    join liquidity_pools 
+        on events.evm_contract_address=liquidity_pools.pool_address
+),
+
+token_prices_usd as (
+    select 
+        tokenprices.block_date,
+        tokenprices.token_address,
+        tokenprices.token_symbol,
+        tokens.decimals,
+        tokenprices.usd_price
+    from tokenprices
+    join tokens 
+        on tokenprices.token_address=tokens.token_address
+),
+
+final_table as (
+    select
+        events_liquidity_pools.log_id,
+        events_liquidity_pools.block_timestamp,
+        events_liquidity_pools.tx_hash,
+        txs.from_address as liquidity_provider,
+        events_liquidity_pools.pool_address,
+        events_liquidity_pools.pool_name,
+        events_liquidity_pools.token0,
+        token0_prices_usd.token_symbol as token0_name,
+        events_liquidity_pools.token1,
+        token1_prices_usd.token_symbol as token1_name,
+        events_liquidity_pools.action,
+        events_liquidity_pools.amount0_raw/pow(10, token0_prices_usd.decimals) 
+            as amount0_adjusted,
+    
+        events_liquidity_pools.amount1_raw/pow(10, token1_prices_usd.decimals) 
+            as amount1_adjusted,
+    
+        events_liquidity_pools.amount0_raw/pow(10, token0_prices_usd.decimals)*token0_prices_usd.usd_price
+            as amount0_usd,
+    
+        events_liquidity_pools.amount1_raw/pow(10, token1_prices_usd.decimals)*token1_prices_usd.usd_price 
+            as amount1_usd
+    
+    from events_liquidity_pools
+        join txs 
+            on events_liquidity_pools.tx_hash=txs.tx_hash
+        -- join token prices table to token0
+        left join token_prices_usd as token0_prices_usd
+            on events_liquidity_pools.token0=token0_prices_usd.token_address 
+                and events_liquidity_pools.block_date=token0_prices_usd.block_date
+        -- join token prices table to token1
+        left join token_prices_usd as token1_prices_usd
+            on events_liquidity_pools.token1=token1_prices_usd.token_address 
+                and events_liquidity_pools.block_date=token1_prices_usd.block_date
+    order by events_liquidity_pools.block_timestamp desc
+)
+
+select * from final_table 

--- a/models/core/sushiswap_lp_actions.yml
+++ b/models/core/sushiswap_lp_actions.yml
@@ -1,0 +1,78 @@
+version: 2
+
+models:
+  - name: sushiswap_lp_actions
+    description: "Harmony Sushiswap LP Actions"
+
+    columns:
+      - name: log_id
+        description: Log identifier composed of tx_hash-event_index
+        tests:
+          - unique
+          - not_null
+
+      - name: block_timestamp
+        description: The timestamp for when the block was collated.
+        tests:
+          - not_null
+
+      - name: tx_hash
+        description: Hash of the transaction (32 Bytes).
+        tests:
+          - not_null
+
+      - name: liquidity_provider
+        description: EVM address of the liquidity provider.
+        tests:
+          - not_null
+
+      - name: pool_address
+        description: EVM address of the liquidity pool involved in the transaction.
+        tests:
+          - not_null
+
+      - name: pool_name
+        description: The name of the liquidity pool.
+        tests:
+          - not_null
+
+      - name: token0
+        description: EVM address of the first token in the token pair.
+        tests:
+          - not_null
+
+      - name: token0_name
+        description: Name of the first token in the token pair.
+        tests:
+          - not_null
+
+      - name: token1
+        description: EVM address of the second token in the token pair.
+        tests:
+          - not_null
+
+      - name: token1_name
+        description: Name of the second token in the token pair.
+        tests:
+          - not_null
+
+      - name: action
+        description: The action executed to the liquidity pool.
+        tests:
+          - not_null
+
+      - name: amount0_adjusted
+        description: The quantity of the first token being added or removed from the pool.
+        tests:
+
+      - name: amount1_adjusted
+        description: The quantity of the second token being added or removed from the pool.
+        tests:
+
+      - name: amount0_usd
+        description: The USD value of the first token being added or removed from the pool.
+        tests:
+
+      - name: amount1_usd
+        description: The USD value of the second token being added or removed from the pool.
+        tests:

--- a/models/core/sushiswap_lp_actions.yml
+++ b/models/core/sushiswap_lp_actions.yml
@@ -44,7 +44,6 @@ models:
       - name: token0_name
         description: Name of the first token in the token pair.
         tests:
-          - not_null
 
       - name: token1
         description: EVM address of the second token in the token pair.
@@ -54,7 +53,6 @@ models:
       - name: token1_name
         description: Name of the second token in the token pair.
         tests:
-          - not_null
 
       - name: action
         description: The action executed to the liquidity pool.


### PR DESCRIPTION
This is the branch to create the table for sushiswap-lp-actions. Here's the sample output running in locally:

```root@c1b01df5aae8:/harmony# dbt run --select sushiswap_lp_actions
Running with dbt=0.21.1
Found 37 models, 303 tests, 0 snapshots, 0 analyses, 180 macros, 0 operations, 8 
seed files, 6 sources, 0 exposures

14:24:43 | Concurrency: 4 threads (target='dev')
14:24:43 |
14:24:43 | 1 of 1 START incremental model DEV.sushiswap_lp_actions.............. ....... [RUN]
14:26:20 | 1 of 1 OK created incremental model DEV.sushiswap_lp_actions......... ....... [SUCCESS 1 in 97.00s]
14:26:20 |
14:26:20 | Finished running 1 incremental model in 103.20s.

Completed successfully

Done. PASS=1 WARN=0 ERROR=0 SKIP=0 TOTAL=1
```