### PR TITLE
swaps: use inner join on LPs instead of a left join

### DIFF
--- a/models/core/swaps.sql
+++ b/models/core/swaps.sql
@@ -36,7 +36,7 @@ final as (
         l.event_inputs:sender::string as from_address,
         l.event_inputs:to as to_address
     from logs as l
-    left join {{ ref('liquidity_pools') }} as p on p.pool_address = l.evm_contract_address
+    join {{ ref('liquidity_pools') }} as p on p.pool_address = l.evm_contract_address
     left join {{ ref('tokens') }} as t0 on t0.token_address = p.token0
     left join {{ ref('tokens') }} as t1 on t1.token_address = p.token1
     where l.event_name = 'Swap'


### PR DESCRIPTION
# Description

Closes #62 

Use an inner join instead of left join to remove null fields.


# Tests 

![image](https://user-images.githubusercontent.com/51023861/161558088-09e44e18-3701-43ce-88aa-1805a81c5891.png)

`dbt test` should still fail now, but a quick removal of null'd fields should make it pass.
