### PR TITLE
add sequence, gap tests

### DIFF
--- a/macros/tests/sequence_gaps.sql
+++ b/macros/tests/sequence_gaps.sql
@@ -1,0 +1,34 @@
+{% test sequence_gaps(
+    model,
+    partition_by,
+    column_name
+) %}
+{%- set partition_sql = partition_by | join(", ") -%}
+{%- set previous_column = "prev_" ~ column_name -%}
+WITH source AS (
+    SELECT
+        {{ partition_sql + "," if partition_sql }}
+        {{ column_name }},
+        LAG(
+            {{ column_name }},
+            1
+        ) over (
+            {{ "PARTITION BY " ~ partition_sql if partition_sql }}
+            ORDER BY
+                {{ column_name }} ASC
+        ) AS {{ previous_column }}
+    FROM
+        {{ model }}
+)
+SELECT
+    {{ partition_sql + "," if partition_sql }}
+    {{ previous_column }},
+    {{ column_name }},
+    {{ column_name }} - {{ previous_column }}
+    - 1 AS gap
+FROM
+    source
+WHERE
+    {{ column_name }} - {{ previous_column }} <> 1
+ORDER BY
+    gap DESC {% endtest %}

--- a/macros/tests/tx_gaps.sql
+++ b/macros/tests/tx_gaps.sql
@@ -1,0 +1,34 @@
+{% test tx_gaps(
+    model,
+    column_block,
+    column_tx_hash
+) %}
+WITH block_base AS (
+    SELECT
+        block_id,
+        tx_count
+    FROM
+        {{ ref('blocks') }}
+),
+model_name AS (
+    SELECT
+        {{ column_block }},
+        COUNT(
+            DISTINCT {{ column_tx_hash }}
+        ) AS model_tx_count
+    FROM
+        {{ model }}
+    GROUP BY
+        {{ column_block }}
+)
+SELECT
+    block_base.block_id,
+    tx_count,
+    model_name.{{ column_block }},
+    model_tx_count
+FROM
+    block_base
+    LEFT JOIN model_name
+    ON block_base.block_id = model_name.{{ column_block }}
+WHERE
+    tx_count <> model_tx_count {% endtest %}

--- a/models/core/blocks.yml
+++ b/models/core/blocks.yml
@@ -5,6 +5,10 @@ models:
   - name: blocks
     description: |-
       This table records all the blocks of Harmony blockchain.
+    tests:
+      - sequence_gaps:
+          column_name: block_id
+          where: BLOCK_TIMESTAMP < CURRENT_DATE
 
     columns:
       - name: block_id

--- a/models/core/txs.yml
+++ b/models/core/txs.yml
@@ -4,6 +4,11 @@ models:
   - name: txs
     description: |-
       This table records all the transactions of the Harmony blockchain.
+    tests:
+      - tx_gaps:
+          column_block: block_number
+          column_tx_hash: tx_hash
+          where: BLOCK_TIMESTAMP < CURRENT_DATE
 
     columns:
       - name: block_timestamp


### PR DESCRIPTION
# Description

Adding sequence gap tests for `blocks` and transaction gap tests for `txs`.
Updated `block_number` to `block_id` in `txs`. 

# Tests

`dbt run` 

![image](https://user-images.githubusercontent.com/101434717/172541390-d8254f13-cf27-464e-8942-a03279d4d376.png)

`dbt test` 
![image](https://user-images.githubusercontent.com/101434717/172541959-8226c402-965b-4757-8f00-170c50090944.png)
![image](https://user-images.githubusercontent.com/101434717/172542008-9f2e9e4e-7ab7-4272-a7d7-dce39c6bd1e1.png)

Notes: 700k+ warnings seem to be gone in `prod`, `tx_gaps` not though


# Checklist

- [ ] Follow [dbt style guide](https://github.com/dbt-labs/corp/blob/main/dbt_style_guide.md)
- [ ] Tag the person(s) responsible for reviewing proposed changes
- [ ] Notes to deployment, if a `full-refresh` is needed for any table
**- full refresh done for `txs` so downstream may need refreshes**
- [ ] Run `dbt docs generate` to update the documentation files if this PR is changing the models in any way.

