### PR TITLE
tokenprice_one: Rebase datasource to tokenprices table

### DIFF
--- a/models/tokenprice/tokenprice_one.sql
+++ b/models/tokenprice/tokenprice_one.sql
@@ -8,68 +8,21 @@
     )
 }}
 
-with
-
-jewel_price as (
+with stage as (
     select
-        *
-    from {{ ref("tokenprice_jewel") }}
-    where {{ incremental_last_x_days("timestamp", 3) }}
-),
-
-
-raw_logs as (
-    select 
-        block_timestamp,
-        java_hextoint(substr(data,3+64*0,64)) as amount0In,
-        java_hextoint(substr(data,3+64*1,64)) as amount1In,
-        java_hextoint(substr(data,3+64*2,64)) as amount0Out,
-        java_hextoint(substr(data,3+64*3,64)) as amount1Out
-    from {{ ref('logs') }}
-    where topics[0] = '0xd78ad95fa46c994b6551d0da85fc275fe613ce37657fb8d5e3d130840159d822' -- Swap
-        and evm_contract_address = '0xeb579ddcd49a7beb3f205c9ff6006bb6390f138f' -- JEWEL/WONE Pool
-        and {{ incremental_last_x_days("block_timestamp", 3) }}
-),
-
-daily_trades as (
-    select 
-        date_trunc('day', block_timestamp) as day_date,
-        sum(amount0In) as sum0in,
-        sum(amount1In) as sum1in,
-        sum(amount0Out) as sum0out,
-        sum(amount1Out) as sum1out
-    from raw_logs
-    group by 1
-),
-
-daily_trades_prices as (
-    select
-        -- column is set to timestamp for future purposes (once we get matt's hourly data)
-        day_date as timestamp,
-        /* 
-            Calculation is done by
-            1. ((bigger token deom) / (smaller token denom)) [because these are integers and not floats]
-            2. converted to correct decimal place (e.g [multiplied] * pow(10,-8))
-            3. converted to USD Price (using 1/result && [multiplied] * jewel.price)
-        */
-        ( (sum0in + sum0out) / (sum1in + sum1out) ) * jewel_price.price as price
-    from daily_trades
-    left join jewel_price
-        on jewel_price.timestamp = daily_trades.day_date
-),
-
-combine as (
-    select 
-        *
-    from daily_trades_prices
+        block_date,
+        usd_price,
+        token_symbol
+    from {{ ref("tokenprices") }}
+    where {{ incremental_load_filter_2("block_date", "timestamp") }}
 ),
 
 final as (
-    select 
-        timestamp,
-        avg(price) as price
-    from combine
-    group by 1
+    select
+        block_date as timestamp,
+        usd_price as price
+    from stage
+    where token_symbol = 'WONE'
 )
 
 select * from final


### PR DESCRIPTION
# Description

`tokenprice_one` table was showing erroneous values, basing ONE price off JEWEL. This PR aims to fix that by basing off `WONE` price in the general `tokenprices` table.

# Tests

![image](https://user-images.githubusercontent.com/51023861/180217830-fb099736-0ae7-4fa4-8efb-176220604001.png)

# Checklist

- [x] Tag the person(s) responsible for reviewing proposed changes - @antonyip 
- [x] Notes to deployment, if a `full-refresh` is needed for any table - Full refresh required for `tokenprice_one`

Fixes #135 
